### PR TITLE
Update JWT version dependency

### DIFF
--- a/omniauth-azure-activedirectory.gemspec
+++ b/omniauth-azure-activedirectory.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.files           = `git ls-files`.split("\n")
   s.require_paths   = ['lib']
 
-  s.add_runtime_dependency 'jwt', '~> 1.5'
+  s.add_dependency 'jwt', ['>= 1.0', '< 3.0']
   s.add_runtime_dependency 'omniauth', '~> 1.1'
 
   s.add_development_dependency 'rake', '~> 10.4'


### PR DESCRIPTION
Required to keep up with omniauth-google-oauth2 gem.